### PR TITLE
chore: fix docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adonis Documentation
 
-This project contains the website hosted on http://adonisjs.com. The pull documentation from [https://github.com/adonisjs/docs](adonisjs/docs) and compile the markup files into HTML.
+This project contains the website hosted on http://adonisjs.com. The pull documentation from [https://github.com/adonisjs/docs](https://github.com/adonisjs/docs) and compile the markup files into HTML.
 
 > Did we told you, the docs are built using AdonisJs itself :smile:
 


### PR DESCRIPTION
The url was pointing to an internal URL of the repo that doesn't exist.
