### PR TITLE
Lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Node modules
 node_modules
 
+# Lock files
+package-lock.json
+yarn.lock
+
 # Bower modules
 bower_components
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
While using latest and greatest managers, lock files are created after every install. IMHO, lock files should be either under version control, or gitignored. I updated for that latter scenario.